### PR TITLE
Add Sleepmode & frame counter improvements.

### DIFF
--- a/Firmware/include/globals.h
+++ b/Firmware/include/globals.h
@@ -56,5 +56,5 @@ float frame_progress = 0;
 float prev_frame_progress = 0;
 
 unsigned long lastActivityTime = millis();
-bool lowPowerMode = false;
+bool sleepMode = false;
 // ---------------------

--- a/Firmware/include/hardware.h
+++ b/Firmware/include/hardware.h
@@ -16,7 +16,7 @@ Adafruit_MAX17048 maxlipo;
 BH1750 lightMeter;
 
 // LiDAR setup
-TFMPlus tfluna;
+TFMPlus tfminiplus;
 HardwareSerial lidarSerial(2); // Using serial port 2
 
 // Display setup

--- a/Firmware/include/inputs.h
+++ b/Firmware/include/inputs.h
@@ -6,38 +6,43 @@ void checkButtons()
   if (lbutton.pressed())
   {
     lastActivityTime = millis();
-    if (ui_mode == "main")
-    {
-      cycleApertures("down");
+    if (sleepMode == true) {
+      sleepMode = false;
     }
-    else if (ui_mode == "config")
-    {
-      config_step++;
-      if (config_step > 5)
+    else {
+      if (ui_mode == "main")
       {
-        config_step = 0;
+        cycleApertures("down");
       }
-    }
-    else if (ui_mode == "calib")
-    {
-      if (calib_step == 0)
+      else if (ui_mode == "config")
       {
-        cycleCalibLenses();
-      }
-      if (calib_step == 1)
-      {
-        calib_distance_set[current_calib_distance] = getLensSensorReading();
-        current_calib_distance++;
-        if (current_calib_distance >= sizeof(CALIB_DISTANCES) / sizeof(CALIB_DISTANCES[0]))
+        config_step++;
+        if (config_step > 5)
         {
-          lenses[calib_lens].calibrated = true;
-          for (int i = 0; i < sizeof(calib_distance_set) / sizeof(calib_distance_set[0]); i++)
+          config_step = 0;
+        }
+      }
+      else if (ui_mode == "calib")
+      {
+        if (calib_step == 0)
+        {
+          cycleCalibLenses();
+        }
+        if (calib_step == 1)
+        {
+          calib_distance_set[current_calib_distance] = getLensSensorReading();
+          current_calib_distance++;
+          if (current_calib_distance >= sizeof(CALIB_DISTANCES) / sizeof(CALIB_DISTANCES[0]))
           {
-            lenses[calib_lens].sensor_reading[i] = calib_distance_set[i];
+            lenses[calib_lens].calibrated = true;
+            for (int i = 0; i < sizeof(calib_distance_set) / sizeof(calib_distance_set[0]); i++)
+            {
+              lenses[calib_lens].sensor_reading[i] = calib_distance_set[i];
+            }
+            savePrefs();
+            selected_lens = calib_lens;
+            ui_mode = "config";
           }
-          savePrefs();
-          selected_lens = calib_lens;
-          ui_mode = "config";
         }
       }
     }
@@ -47,6 +52,10 @@ void checkButtons()
   if (rbutton.rose())
   {
     lastActivityTime = millis();
+    if (sleepMode == true) {
+      sleepMode = false;
+    }
+    else {
     if (rbutton.previousDuration() > 5000)
     {
       if (ui_mode == "main")
@@ -56,63 +65,64 @@ void checkButtons()
     }
     else
     {
-      if (ui_mode == "main")
-      {
-        cycleApertures("up");
-      }
-      else if (ui_mode == "config")
-      {
-        if (config_step == 0)
+        if (ui_mode == "main")
         {
-          cycleISOs();
+          cycleApertures("up");
         }
-        else if (config_step == 1)
+        else if (ui_mode == "config")
         {
-          cycleFormats();
+          if (config_step == 0)
+          {
+            cycleISOs();
+          }
+          else if (config_step == 1)
+          {
+            cycleFormats();
+          }
+          else if (config_step == 2)
+          {
+            cycleLenses();
+            int non_zero_aperture_index = getFirstNonZeroAperture();
+            aperture = lenses[selected_lens].apertures[non_zero_aperture_index];
+            aperture_index = non_zero_aperture_index;
+          }
+          else if (config_step == 3)
+          {
+            calib_step = 0;
+            calib_lens = selected_lens;
+            current_calib_distance = 0;
+            memset(calib_distance_set, 0, sizeof(calib_distance_set));
+            ui_mode = "calib";
+          }
+          else if (config_step == 4)
+          {
+            encoder.setEncoderPosition(0);
+            encoder_value = 0;
+            prev_encoder_value = 0;
+            film_counter = 0;
+            frame_progress = 0;
+            prev_frame_progress = 0;
+            savePrefs();
+            ui_mode = "main";
+            config_step = 0;
+          }
+          else if (config_step == 5)
+          {
+            ui_mode = "main";
+            config_step = 0;
+          }
         }
-        else if (config_step == 2)
+        else if (ui_mode == "calib")
         {
-          cycleLenses();
-          int non_zero_aperture_index = getFirstNonZeroAperture();
-          aperture = lenses[selected_lens].apertures[non_zero_aperture_index];
-          aperture_index = non_zero_aperture_index;
-        }
-        else if (config_step == 3)
-        {
-          calib_step = 0;
-          calib_lens = selected_lens;
-          current_calib_distance = 0;
-          memset(calib_distance_set, 0, sizeof(calib_distance_set));
-          ui_mode = "calib";
-        }
-        else if (config_step == 4)
-        {
-          encoder.setEncoderPosition(0);
-          encoder_value = 0;
-          prev_encoder_value = 0;
-          film_counter = 0;
-          frame_progress = 0;
-          prev_frame_progress = 0;
-          savePrefs();
-          ui_mode = "main";
-          config_step = 0;
-        }
-        else if (config_step == 5)
-        {
-          ui_mode = "main";
-          config_step = 0;
-        }
-      }
-      else if (ui_mode == "calib")
-      {
-        if (calib_step == 0)
-        {
-          calib_step = 1;
-        }
-        else if (calib_step == 1)
-        {
-          calib_step = 0;
-          ui_mode = "config";
+          if (calib_step == 0)
+          {
+            calib_step = 1;
+          }
+          else if (calib_step == 1)
+          {
+            calib_step = 0;
+            ui_mode = "config";
+          }
         }
       }
     }

--- a/Firmware/include/interface.h
+++ b/Firmware/include/interface.h
@@ -392,4 +392,22 @@ void drawExternalUI()
   display_ext.display();
 }
 
+void drawSleepUI()
+{
+  display.clearDisplay();
+  display_ext.clearDisplay();
+
+  u8g2_ext.setFontMode(1);
+  u8g2_ext.setFontDirection(0);
+  u8g2_ext.setForegroundColor(WHITE);
+  u8g2_ext.setBackgroundColor(BLACK);
+  u8g2_ext.setFont(u8g2_font_6x10_mf);
+
+  u8g2_ext.setCursor(2, 8);
+  u8g2_ext.print(F("Zzzzzz..."));
+
+  display.display();
+  display_ext.display();
+}
+
 // ---------------------

--- a/Firmware/include/interface.h
+++ b/Firmware/include/interface.h
@@ -401,13 +401,16 @@ void drawSleepUI()
   u8g2_ext.setFontDirection(0);
   u8g2_ext.setForegroundColor(WHITE);
   u8g2_ext.setBackgroundColor(BLACK);
-  u8g2_ext.setFont(u8g2_font_6x10_mf);
+  u8g2_ext.setFont(u8g2_font_10x20_mf);
 
-  u8g2_ext.setCursor(2, 8);
-  u8g2_ext.print(F("Zzzzzz..."));
+  u8g2_ext.setCursor(8, 30);
+  u8g2_ext.print(F("ZzzZZzZz..."));
 
   display.display();
   display_ext.display();
+
+  sspixel.setPixelColor(0, sspixel.Color(0, 0, 0));
+  sspixel.show();
 }
 
 // ---------------------

--- a/Firmware/include/mrfconstants.h
+++ b/Firmware/include/mrfconstants.h
@@ -1,4 +1,7 @@
 // Constants
+#define FWVERSION "3.5"
+#define SLEEPTIMEOUT 60000
+
 #define RXD2 RX
 #define TXD2 TX
 

--- a/Firmware/include/setfuncs.h
+++ b/Firmware/include/setfuncs.h
@@ -42,7 +42,12 @@ void setLensDistance()
 
   if (lens_sensor_reading != prev_lens_sensor_reading)
   {
-    lastActivityTime = millis();
+
+    if (abs(lens_sensor_reading - prev_lens_sensor_reading) > 3)
+    {
+      lastActivityTime = millis();
+    }
+
     prev_lens_sensor_reading = lens_sensor_reading;
 
     for (int i = 0; i < sizeof(lenses[selected_lens].sensor_reading) / sizeof(lenses[selected_lens].sensor_reading[0]); i++)
@@ -70,11 +75,6 @@ void setLensDistance()
       }
     }
 
-    if (abs(lens_sensor_reading - prev_lens_sensor_reading) > 5)
-    {
-      lastActivityTime = millis();
-    }
-
   }
 }
 
@@ -96,16 +96,18 @@ void setFilmCounter()
       else if (film_formats[selected_format].sensor[i] < encoder_value && encoder_value < film_formats[selected_format].sensor[i + 1])
       {
         // Check if the encoder value is within +/- 2 of the next frame
-        if (abs(encoder_value - film_formats[selected_format].sensor[i + 1]) <= 2)
+        if (abs(encoder_value - film_formats[selected_format].sensor[i + 1]) <= 1)
         {
           // Snap to the next frame
           film_counter = film_formats[selected_format].frame[i + 1];
+          frame_progress = 0;
         }
         else
         {
           film_counter = film_formats[selected_format].frame[i];
+          frame_progress = static_cast<float>(encoder_value - film_formats[selected_format].sensor[i]) / (film_formats[selected_format].sensor[i + 1] - film_formats[selected_format].sensor[i]);
         }
-        frame_progress = static_cast<float>(encoder_value - film_formats[selected_format].sensor[i]) / (film_formats[selected_format].sensor[i + 1] - film_formats[selected_format].sensor[i]);
+        
       }
     }
 

--- a/Firmware/include/setfuncs.h
+++ b/Firmware/include/setfuncs.h
@@ -2,7 +2,7 @@
 // ---------------------
 void setDistance()
 {
-  if (tfluna.getData(distance))
+  if (tfminiplus.getData(distance))
   { // Get data from Lidar
     Serial.println(distance);
     distance = distance + LIDAR_OFFSET;
@@ -70,6 +70,11 @@ void setLensDistance()
       }
     }
 
+    if (abs(lens_sensor_reading - prev_lens_sensor_reading) > 5)
+    {
+      lastActivityTime = millis();
+    }
+
   }
 }
 
@@ -90,11 +95,21 @@ void setFilmCounter()
       }
       else if (film_formats[selected_format].sensor[i] < encoder_value && encoder_value < film_formats[selected_format].sensor[i + 1])
       {
-        film_counter = film_formats[selected_format].frame[i];
+        // Check if the encoder value is within +/- 2 of the next frame
+        if (abs(encoder_value - film_formats[selected_format].sensor[i + 1]) <= 2)
+        {
+          // Snap to the next frame
+          film_counter = film_formats[selected_format].frame[i + 1];
+        }
+        else
+        {
+          film_counter = film_formats[selected_format].frame[i];
+        }
         frame_progress = static_cast<float>(encoder_value - film_formats[selected_format].sensor[i]) / (film_formats[selected_format].sensor[i + 1] - film_formats[selected_format].sensor[i]);
       }
     }
 
+    lastActivityTime = millis();
     savePrefs();
   }
 }
@@ -178,6 +193,18 @@ void setLightMeter()
       }
        
     }
+  }
+}
+
+void toggleLidar()
+{
+  if (sleepMode == true)
+  {
+    tfminiplus.sendCommand(DISABLE_OUTPUT, 0);
+  }
+  else
+  {
+    tfminiplus.sendCommand(ENABLE_OUTPUT, 0);
   }
 }
 // ---------------------

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -74,7 +74,8 @@ void setup()
   display_ext.setTextSize(2); // Draw 2X-scale text
   display_ext.setTextColor(SSD1306_WHITE);
   display_ext.setCursor(20, 10);
-  display_ext.println(F("MRF v3.0"));
+  display_ext.print(F("MRF "));
+  display_ext.println(FWVERSION);
   display_ext.display();
 
   delay(1500);
@@ -116,8 +117,7 @@ void setup()
 
 void loop()
 {
-
-  if (millis() - lastActivityTime > 30000) { // Step 3
+  if (millis() - lastActivityTime > SLEEPTIMEOUT) { // Step 3
     sleepMode = true;
   }
 
@@ -125,21 +125,18 @@ void loop()
 
   if (sleepMode == true)
   {
-    drawSleepUI();
     toggleLidar();
-    return;
+    drawSleepUI();
   }
-  else {
+  else { 
+    toggleLidar();
     if (ui_mode == "main")
-      {
-        toggleLidar();
-        
+      { 
         setDistance();
         setLensDistance();
         setVoltage();
         setLightMeter();
         drawMainUI();
-        setFilmCounter();
       }
       else if (ui_mode == "config")
       {
@@ -149,7 +146,7 @@ void loop()
       {
         drawCalibUI();
       }
-
+      setFilmCounter();
       drawExternalUI();
   }
 }

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -85,7 +85,7 @@ void setup()
   // Start the LiDAR sensor
   lidarSerial.begin(115200, SERIAL_8N1, RXD2, TXD2);
   delay(20);
-  tfluna.begin(&lidarSerial);
+  tfminiplus.begin(&lidarSerial);
 
   // Clear the moving average arrays
   for (int i = 0; i < SMOOTHING_WINDOW_SIZE; i++)
@@ -116,26 +116,41 @@ void setup()
 
 void loop()
 {
+
+  if (millis() - lastActivityTime > 30000) { // Step 3
+    sleepMode = true;
+  }
+
   checkButtons();
 
-  if (ui_mode == "main")
+  if (sleepMode == true)
   {
-    setDistance();
-    setLensDistance();
-    setVoltage();
-    setLightMeter();
-    drawMainUI();
-    setFilmCounter();
+    drawSleepUI();
+    toggleLidar();
+    return;
   }
-  else if (ui_mode == "config")
-  {
-    drawConfigUI();
-  }
-  else if (ui_mode == "calib")
-  {
-    drawCalibUI();
-  }
+  else {
+    if (ui_mode == "main")
+      {
+        toggleLidar();
+        
+        setDistance();
+        setLensDistance();
+        setVoltage();
+        setLightMeter();
+        drawMainUI();
+        setFilmCounter();
+      }
+      else if (ui_mode == "config")
+      {
+        drawConfigUI();
+      }
+      else if (ui_mode == "calib")
+      {
+        drawCalibUI();
+      }
 
-  drawExternalUI();
+      drawExternalUI();
+  }
 }
 // ---------------------


### PR DESCRIPTION
Version 3.5 of the firmware introduces sleep mode. After no focus, button, or advance knob activity for 1 minute, the camera will go into sleep mode, turning off the main display and the LiDAR, and setting the external display to a bunch of Zs. 

The will significantly improve battery life, and the user can keep the camera switched on throughout the shooting session. 

In addition, the frame counter now accounts for 3d-printed ratchet slop and should snap into place more consistently. 